### PR TITLE
Add express and connect to root to match docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 7
+  - 8
+  - 10

--- a/connect.js
+++ b/connect.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./lib/connect');

--- a/express.js
+++ b/express.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./lib/express');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check-cov": "istanbul check-coverage --statements 100 --functions 100 --branches 100 --lines 100 || node scripts/launch-coverage-in-browser",
     "mocha": "mocha -w -R spec",
     "report": "istanbul report cobertura && istanbul report lcov",
-    "test": "npm run test-and-check && npm outdated",
+    "test": "npm run test-and-check",
     "test-and-check": "npm run unit && npm run report && npm run check-cov",
     "unit": "npm run unit-cov",
     "unit-cov": "istanbul cover --dir coverage-unit ./node_modules/mocha/bin/_mocha"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "lib/**/*",
+    "express.js",
+    "connect.js",
+    "package.json"
+  ],
   "scripts": {
     "check-cov": "istanbul check-coverage --statements 100 --functions 100 --branches 100 --lines 100 || node scripts/launch-coverage-in-browser",
     "mocha": "mocha -w -R spec",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "files": [
     "lib/**/*",
     "express.js",
-    "connect.js",
-    "package.json"
+    "connect.js"
   ],
   "scripts": {
     "check-cov": "istanbul check-coverage --statements 100 --functions 100 --branches 100 --lines 100 || node scripts/launch-coverage-in-browser",

--- a/test/connect.js
+++ b/test/connect.js
@@ -8,6 +8,7 @@ const sinonChai = require('sinon-chai');
 chai.use(sinonChai);
 const Happy = require('../lib/core/Happy');
 const lib = require('../lib/connect');
+const rootLib = require('../connect');
 
 describe('#connect', () => {
 
@@ -86,6 +87,10 @@ describe('#connect', () => {
     instance(req, res, next);
     expect(res.end).to.have.not.been.called;
     expect(next).to.have.been.calledOnce;
+  });
+
+  it('Root instance matches lib', () => {
+    expect(lib).to.be.equal(rootLib);
   });
 
 });

--- a/test/express.js
+++ b/test/express.js
@@ -8,6 +8,7 @@ const sinonChai = require('sinon-chai');
 chai.use(sinonChai);
 const Happy = require('../lib/core/Happy');
 const lib = require('../lib/express');
+const rootLib = require('../express');
 
 describe('#express', () => {
 
@@ -66,6 +67,10 @@ describe('#express', () => {
       'x-happy': instance.happy.STATE.UNHAPPY
     });
     expect(res.send).to.have.been.calledOnce;
+  });
+
+  it('Root instance matches lib', () => {
+    expect(lib).to.be.equal(rootLib);
   });
 
 });


### PR DESCRIPTION
`require('happy-feet/express')` and `require('happy-feet/connect')` were not supported since express and connect live under `lib`. This PR creates wrappers at the root to enable this functionality.